### PR TITLE
fix: centralize lifecycle ignore_changes extraction and use fresh block copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ A Terraform root path must be specified either via environment variable or confi
 
 GitHub integration requires appropriate repository permissions and a valid token
 
-Validation respects Terraform's lifecycle ignore_changes directives
+Validation respects Terraform lifecycle ignore_changes directives, and diffy skips attributes that providers mark as computed-only so you can focus on values you must declare
 
 ## Contributors
 


### PR DESCRIPTION
## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know.

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything)

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_resource` - support for the `example` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #0000
